### PR TITLE
fix: await cookies in session

### DIFF
--- a/src/app/api/history/[id]/route.ts
+++ b/src/app/api/history/[id]/route.ts
@@ -25,7 +25,7 @@ export async function GET(
   if (!id) {
     return NextResponse.json({ error: "Missing id" }, { status: 400 });
   }
-  const sessionId = getOrCreateSession();
+  const sessionId = await getOrCreateSession();
   await ensureTable();
   const { rows } = await sql<{
     id: string;

--- a/src/app/api/history/route.ts
+++ b/src/app/api/history/route.ts
@@ -18,7 +18,7 @@ async function ensureTable() {
 }
 
 export async function GET() {
-  const sessionId = getOrCreateSession();
+  const sessionId = await getOrCreateSession();
   await ensureTable();
   const { rows } = await sql<{
     id: string;
@@ -43,7 +43,7 @@ export async function GET() {
 }
 
 export async function POST(req: NextRequest) {
-  const sessionId = getOrCreateSession();
+  const sessionId = await getOrCreateSession();
   const body = (await req.json()) as {
     id?: string;
     source: string;

--- a/src/lib/session.ts
+++ b/src/lib/session.ts
@@ -1,8 +1,8 @@
 import { cookies } from "next/headers";
 import { randomUUID } from "crypto";
 
-export function getOrCreateSession(): string {
-  const jar = cookies();
+export async function getOrCreateSession(): Promise<string> {
+  const jar = await cookies();
   let sid = jar.get("vb_session")?.value;
   if (!sid) {
     sid = randomUUID();


### PR DESCRIPTION
## Summary
- make session retrieval async and await cookies API
- await session ID lookups in history GET and POST handlers

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bcd0f01ec8833394df6dee80bd6ebb