### PR TITLE
feat: add vertex ai image generation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,15 @@
+# OpenRouter (text generation and optional image fallback)
+OPENROUTER_API_KEY=
+# Default models
+OPENROUTER_TEXT_MODEL=openai/gpt-5-mini
+OPENROUTER_IMAGE_MODEL=google/gemini-2.5-flash-image-preview
+
+# Vertex AI image generation
+VERTEX_PROJECT_ID=
+VERTEX_LOCATION=
+VERTEX_API_KEY=
+# Optional: override default model
+# VERTEX_IMAGE_MODEL=gemini-2.5-flash-image-preview
+
+# Image provider: vertex (default) or openrouter
+IMAGE_PROVIDER=vertex

--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ yarn-error.log*
 
 # env files (can opt-in for committing if needed)
 .env*
+!.env.example
 
 # vercel
 .vercel

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@ VintedBoost — MVP Try-On + Description Vinted (Next.js + OpenRouter)
 Quick start
 
 - Copy `.env.example` to `.env.local` and set `OPENROUTER_API_KEY`.
+- Set Google Vertex AI variables `VERTEX_PROJECT_ID`, `VERTEX_LOCATION` and `VERTEX_API_KEY` for image generation.
 - If you want server persistence locally, also set `POSTGRES_URL` to a Vercel Postgres connection string.
 - Run `npm run dev` then open http://localhost:3000
 - Upload a “non porté” photo, set the reference, choose mannequin options, click “Générer”.
@@ -11,8 +12,7 @@ Quick start
 Notes
 
 - Texte: model defaults to `openai/gpt-5-mini` (change via `OPENROUTER_TEXT_MODEL`).
-- Images: model `google/gemini-2.5-flash-image-preview` (overridable via `OPENROUTER_IMAGE_MODEL`).
-- Images are returned as base64 Data URLs and are downloadable.
+- Images: by default uses Google Vertex AI `gemini-2.5-flash-image-preview`. Switch to OpenRouter via `IMAGE_PROVIDER=openrouter` and set `OPENROUTER_API_KEY`. Images are returned as base64 Data URLs and are downloadable.
 - History persists locally in `localStorage` with “dupliquer l’annonce”.
 - A prompt preview shows the exact instruction sent to the image model, adapted for the Vinted marketplace and “mannequin réaliste”. No custom free‑text is required.
 
@@ -27,3 +27,7 @@ OpenRouter references
 
 - API: https://openrouter.ai/docs/api-reference/overview
 - Model page: https://openrouter.ai/google/gemini-2.5-flash-image-preview
+
+Vertex AI references
+
+- Model docs: https://cloud.google.com/vertex-ai/generative-ai/docs/models/gemini/2-5-flash

--- a/src/app/api/generate-images/route.ts
+++ b/src/app/api/generate-images/route.ts
@@ -4,6 +4,7 @@ import {
   OpenRouterChatCompletionResponse,
   OpenRouterChatMessage,
 } from "@/lib/openrouter";
+import { vertexFetch } from "@/lib/vertex";
 import { MannequinOptions, buildInstruction } from "@/lib/prompt";
 import { normalizeImageDataUrl } from "@/lib/image";
 
@@ -17,11 +18,12 @@ function getImageModel() {
 }
 
 export async function POST(req: NextRequest) {
-  const { imageDataUrl, options, productReference, count } = (await req.json()) as {
+  const { imageDataUrl, options, productReference, count, provider } = (await req.json()) as {
     imageDataUrl: string; // Data URL (data:image/...;base64,...)
     options?: MannequinOptions;
     productReference?: string;
     count?: number; // default 1
+    provider?: string;
   };
 
   if (!imageDataUrl || typeof imageDataUrl !== "string") {
@@ -76,6 +78,7 @@ export async function POST(req: NextRequest) {
 
   const imagesOut: string[] = [];
   const instructionEchoes: string[] = [];
+  const providerUsed = (provider || process.env.IMAGE_PROVIDER || "vertex").toLowerCase();
   try {
     for (let i = 0; i < n; i++) {
       const instruction = buildInstruction(
@@ -84,34 +87,39 @@ export async function POST(req: NextRequest) {
         i === 0 ? "pose principale" : i === 1 ? "léger mouvement" : "trois-quarts"
       );
       instructionEchoes.push(instruction);
-      const messages: OpenRouterChatMessage[] = [
-        {
-          role: "system",
-          content:
-            "Tu génères UNIQUEMENT une image correspondant aux instructions. Ne retourne pas de texte.",
-        },
-        {
-          role: "user",
-          content: [
-            { type: "text", text: instruction },
-            { type: "image_url", image_url: { url: safeImageDataUrl } },
-          ],
-        },
-      ];
-      const payload = {
-        model: getImageModel(),
-        messages,
-        modalities: ["image"],
-        // Some providers honor this to prefer non-text responses
-        max_output_tokens: 0,
-      };
+      if (providerUsed === "openrouter") {
+        const messages: OpenRouterChatMessage[] = [
+          {
+            role: "system",
+            content:
+              "Tu génères UNIQUEMENT une image correspondant aux instructions. Ne retourne pas de texte.",
+          },
+          {
+            role: "user",
+            content: [
+              { type: "text", text: instruction },
+              { type: "image_url", image_url: { url: safeImageDataUrl } },
+            ],
+          },
+        ];
+        const payload = {
+          model: getImageModel(),
+          messages,
+          modalities: ["image"],
+          // Some providers honor this to prefer non-text responses
+          max_output_tokens: 0,
+        };
 
-      const data = await openrouterFetch<OpenRouterChatCompletionResponse>(
-        payload,
-        { cache: "no-store" }
-      );
-      const urls = extractImageUrls(data);
-      if (urls[0]) imagesOut.push(urls[0]);
+        const data = await openrouterFetch<OpenRouterChatCompletionResponse>(
+          payload,
+          { cache: "no-store" }
+        );
+        const urls = extractImageUrls(data);
+        if (urls[0]) imagesOut.push(urls[0]);
+      } else {
+        const urls = await vertexFetch(instruction, safeImageDataUrl);
+        if (urls[0]) imagesOut.push(urls[0]);
+      }
     }
 
     if (imagesOut.length === 0) {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -78,6 +78,9 @@ export default function Home() {
   const POSES = ["face", "trois-quarts", "profil", "assis", "marche"] as const;
   const STYLES = ["professionnel", "amateur"] as const;
   const BACKGROUNDS = ["chambre", "salon", "studio", "extérieur"] as const;
+  const PROVIDERS = ["vertex", "openrouter"] as const;
+
+  const [imageProvider, setImageProvider] = useState<string>("vertex");
 
   const canGenerate = useMemo(
     () => Boolean(imageDataUrl && !generating),
@@ -114,7 +117,7 @@ export default function Home() {
       const imgRes = await fetch("/api/generate-images", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ imageDataUrl, options, count: 1 }),
+        body: JSON.stringify({ imageDataUrl, options, count: 1, provider: imageProvider }),
       });
       const imgJson = await imgRes.json();
       if (!imgRes.ok) throw new Error(imgJson?.error || "Erreur images");
@@ -277,6 +280,10 @@ export default function Home() {
         setImageOptsEnabled(rawImgOptsEnabled === "true");
         setOptionsOpen(rawImgOptsEnabled === "true");
       }
+      const rawProvider = localStorage.getItem("vintedboost_image_provider");
+      if (rawProvider === "openrouter" || rawProvider === "vertex") {
+        setImageProvider(rawProvider);
+      }
       const rawProd = localStorage.getItem("vintedboost_product");
       if (rawProd) {
         try {
@@ -349,6 +356,12 @@ export default function Home() {
       localStorage.setItem("vintedboost_desc_enabled", String(descEnabled));
     } catch {}
   }, [descEnabled]);
+
+  useEffect(() => {
+    try {
+      localStorage.setItem("vintedboost_image_provider", imageProvider);
+    } catch {}
+  }, [imageProvider]);
 
   return (
     <div className="min-h-dvh bg-gradient-to-b from-gray-50 to-white text-gray-900 dark:from-gray-950 dark:to-gray-900 dark:text-gray-100">
@@ -665,7 +678,27 @@ export default function Home() {
                 )}
               >
                 {/* Options avancées modifiables seulement si imageOptsEnabled */}
-                
+
+                <div>
+                  <div className="mb-1 text-[10px] font-medium uppercase tracking-wider text-gray-600 dark:text-gray-300">Fournisseur</div>
+                  <div className="flex flex-wrap gap-2">
+                    {PROVIDERS.map((p) => (
+                      <button
+                        key={p}
+                        onClick={() => setImageProvider(p)}
+                        className={cx(
+                          "rounded-md border px-2 py-1 text-xs uppercase",
+                          imageProvider === p
+                            ? "bg-brand-600 text-white border-brand-600"
+                            : "bg-white text-gray-700 border-gray-300 hover:bg-gray-50 dark:bg-gray-900 dark:text-gray-200 dark:border-gray-700 dark:hover:bg-gray-800"
+                        )}
+                      >
+                        {p}
+                      </button>
+                    ))}
+                  </div>
+                </div>
+
                 <div>
                   <div className="mb-1 text-[10px] font-medium uppercase tracking-wider text-gray-600 dark:text-gray-300">Pose</div>
                   <div className="flex flex-wrap gap-2">

--- a/src/lib/vertex.ts
+++ b/src/lib/vertex.ts
@@ -1,0 +1,58 @@
+export async function vertexFetch(
+  instruction: string,
+  imageDataUrl: string,
+): Promise<string[]> {
+  const projectId = process.env.VERTEX_PROJECT_ID;
+  const location = process.env.VERTEX_LOCATION;
+  const apiKey = process.env.VERTEX_API_KEY;
+  if (!projectId || !location || !apiKey) {
+    throw new Error(
+      "Missing VERTEX_PROJECT_ID, VERTEX_LOCATION or VERTEX_API_KEY. Add them to .env.local (see .env.example).",
+    );
+  }
+  const model = process.env.VERTEX_IMAGE_MODEL || "gemini-2.5-flash-image-preview";
+  const endpoint = `https://${location}-aiplatform.googleapis.com/v1beta1/projects/${projectId}/locations/${location}/publishers/google/models/${model}:generateContent?key=${apiKey}`;
+
+  const match = imageDataUrl.match(/^data:(image\/[^;]+);base64,(.+)$/);
+  if (!match) {
+    throw new Error("Invalid image data URL");
+  }
+  const mimeType = match[1];
+  const data = match[2];
+
+  const payload = {
+    contents: [
+      {
+        role: "user",
+        parts: [
+          { text: instruction },
+          { inline_data: { mime_type: mimeType, data } },
+        ],
+      },
+    ],
+  };
+
+  const res = await fetch(endpoint, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(payload),
+  });
+  if (!res.ok) {
+    const text = await res.text().catch(() => "");
+    throw new Error(`Vertex AI error ${res.status}: ${text}`);
+  }
+  const json = (await res.json()) as {
+    candidates?: Array<{ content?: { parts?: Array<{ inline_data?: { mime_type?: string; data?: string } }> } }>;
+  };
+  const images: string[] = [];
+  for (const c of json.candidates || []) {
+    for (const p of c.content?.parts || []) {
+      const d = p.inline_data?.data;
+      if (d) {
+        const mime = p.inline_data?.mime_type || mimeType || "image/png";
+        images.push(`data:${mime};base64,${d}`);
+      }
+    }
+  }
+  return images;
+}


### PR DESCRIPTION
## Summary
- add Vertex AI client for Gemini 2.5 Flash image preview
- use Vertex by default for image generation with optional OpenRouter fallback
- expose provider choice in UI and document new env vars

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c052723c6c83338af09a2ac98f4979