### PR TITLE
feat: add Google AI image generation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,13 @@
+# OpenRouter configuration
+OPENROUTER_API_KEY=
+# Optional: customize OpenRouter headers
+OPENROUTER_HTTP_REFERER=
+OPENROUTER_X_TITLE=
+# Optional: override image model when using OpenRouter
+OPENROUTER_IMAGE_MODEL=
+
+# Google AI configuration
+GOOGLE_AI_API_KEY=
+
+# Default image provider (google | openrouter)
+IMAGE_PROVIDER=google

--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ yarn-error.log*
 
 # env files (can opt-in for committing if needed)
 .env*
+!.env.example
 
 # vercel
 .vercel

--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
-VintedBoost — MVP Try-On + Description Vinted (Next.js + OpenRouter)
+VintedBoost — MVP Try-On + Description Vinted (Next.js + Google AI / OpenRouter)
 
 Quick start
 
-- Copy `.env.example` to `.env.local` and set `OPENROUTER_API_KEY`.
+- Copy `.env.example` to `.env.local` and set `OPENROUTER_API_KEY` and `GOOGLE_AI_API_KEY`.
+- Optional: set `IMAGE_PROVIDER` (`google` by default) to `openrouter` if you prefer OpenRouter for images.
 - If you want server persistence locally, also set `POSTGRES_URL` to a Vercel Postgres connection string.
 - Run `npm run dev` then open http://localhost:3000
 - Upload a “non porté” photo, set the reference, choose mannequin options, click “Générer”.
@@ -10,8 +11,8 @@ Quick start
 
 Notes
 
-- Texte: model defaults to `openai/gpt-5-mini` (change via `OPENROUTER_TEXT_MODEL`).
-- Images: model `google/gemini-2.5-flash-image-preview` (overridable via `OPENROUTER_IMAGE_MODEL`).
+- Descriptions: toujours générées via OpenRouter avec le modèle `openai/gpt-5-mini`.
+- Génération d'images: Google AI (`gemini-2.5-flash-image-preview`) par défaut, basculable vers OpenRouter via l'interface Paramètres ou `IMAGE_PROVIDER`.
 - Images are returned as base64 Data URLs and are downloadable.
 - History persists locally in `localStorage` with “dupliquer l’annonce”.
 - A prompt preview shows the exact instruction sent to the image model, adapted for the Vinted marketplace and “mannequin réaliste”. No custom free‑text is required.

--- a/src/app/api/describe-photo/route.ts
+++ b/src/app/api/describe-photo/route.ts
@@ -6,14 +6,8 @@ import {
 } from "@/lib/openrouter";
 import { normalizeImageDataUrl } from "@/lib/image";
 
-function getTextModel() {
-  return (
-    process.env.OPENROUTER_TEXT_MODEL ||
-    process.env.TEXT_MODEL ||
-    // default requested by user
-    "openai/gpt-5-mini"
-  );
-}
+// Locked model for photo descriptions
+const TEXT_MODEL = "openai/gpt-5-mini";
 
 function safeJsonParse<T>(text: string): T | null {
   try {
@@ -110,7 +104,7 @@ export async function POST(req: NextRequest) {
   ];
 
   const payload = {
-    model: getTextModel(),
+    model: TEXT_MODEL,
     messages,
     response_format: { type: "json_object" },
   };

--- a/src/app/api/describe/route.ts
+++ b/src/app/api/describe/route.ts
@@ -5,14 +5,8 @@ import {
   OpenRouterChatMessage,
 } from "@/lib/openrouter";
 
-function getTextModel() {
-  return (
-    process.env.OPENROUTER_TEXT_MODEL ||
-    process.env.TEXT_MODEL ||
-    // Requested default; if unavailable, callers can set env above
-    "openai/gpt-5-mini"
-  );
-}
+// Locked model for product descriptions
+const TEXT_MODEL = "openai/gpt-5-mini";
 
 function safeJsonParse<T>(text: string): T | null {
   try {
@@ -80,7 +74,7 @@ Indices: ${hints || "(aucun)"}`;
   ];
 
   const payload = {
-    model: getTextModel(),
+    model: TEXT_MODEL,
     messages,
     // Prefer JSON output if supported by provider
     response_format: { type: "json_object" },

--- a/src/app/api/generate-images/route.ts
+++ b/src/app/api/generate-images/route.ts
@@ -4,10 +4,15 @@ import {
   OpenRouterChatCompletionResponse,
   OpenRouterChatMessage,
 } from "@/lib/openrouter";
+import { googleAiFetch } from "@/lib/google-ai";
 import { MannequinOptions, buildInstruction } from "@/lib/prompt";
 import { normalizeImageDataUrl } from "@/lib/image";
 
 export const runtime = "nodejs";
+
+function getImageProvider() {
+  return (process.env.IMAGE_PROVIDER || "google").toLowerCase();
+}
 
 function getImageModel() {
   return (
@@ -41,7 +46,9 @@ export async function POST(req: NextRequest) {
     );
   }
 
-  function extractImageUrls(resp: OpenRouterChatCompletionResponse): string[] {
+  function extractOpenRouterImageUrls(
+    resp: OpenRouterChatCompletionResponse
+  ): string[] {
     type ImagesPart = { image_url?: { url?: string } };
     type ChoiceMessage = { images?: ImagesPart[]; content?: unknown };
     type ChoiceDelta = { images?: ImagesPart[] };
@@ -74,8 +81,40 @@ export async function POST(req: NextRequest) {
     return Array.from(new Set(urls));
   }
 
+  function extractGoogleImageUrls(resp: unknown): string[] {
+    const urls: string[] = [];
+    type Part = { inline_data?: { data?: string; mime_type?: string } };
+    const parts = (
+      resp as { candidates?: Array<{ content?: { parts?: Part[] } }> }
+    )?.candidates?.[0]?.content?.parts || [];
+    for (const p of parts as Part[]) {
+      const d = p.inline_data;
+      if (d?.data && d?.mime_type) {
+        urls.push(`data:${d.mime_type};base64,${d.data}`);
+      }
+    }
+    return Array.from(new Set(urls));
+  }
+
+  const match = safeImageDataUrl.match(
+    /^data:(image\/[a-zA-Z+.-]+);base64,([A-Za-z0-9+/=]+)$/
+  );
+  if (!match) {
+    return NextResponse.json(
+      { error: "Invalid image data" },
+      { status: 400 }
+    );
+  }
+  const mimeType = match[1];
+  const base64Data = match[2];
+
   const imagesOut: string[] = [];
   const instructionEchoes: string[] = [];
+  const providerHeader = req.headers.get("x-image-provider");
+  const provider =
+    providerHeader === "openrouter" || providerHeader === "google"
+      ? providerHeader
+      : getImageProvider();
   try {
     for (let i = 0; i < n; i++) {
       const instruction = buildInstruction(
@@ -84,34 +123,44 @@ export async function POST(req: NextRequest) {
         i === 0 ? "pose principale" : i === 1 ? "léger mouvement" : "trois-quarts"
       );
       instructionEchoes.push(instruction);
-      const messages: OpenRouterChatMessage[] = [
-        {
-          role: "system",
-          content:
-            "Tu génères UNIQUEMENT une image correspondant aux instructions. Ne retourne pas de texte.",
-        },
-        {
-          role: "user",
-          content: [
-            { type: "text", text: instruction },
-            { type: "image_url", image_url: { url: safeImageDataUrl } },
-          ],
-        },
-      ];
-      const payload = {
-        model: getImageModel(),
-        messages,
-        modalities: ["image"],
-        // Some providers honor this to prefer non-text responses
-        max_output_tokens: 0,
-      };
-
-      const data = await openrouterFetch<OpenRouterChatCompletionResponse>(
-        payload,
-        { cache: "no-store" }
-      );
-      const urls = extractImageUrls(data);
-      if (urls[0]) imagesOut.push(urls[0]);
+      if (provider === "openrouter") {
+        const messages: OpenRouterChatMessage[] = [
+          {
+            role: "system",
+            content:
+              "Tu génères UNIQUEMENT une image correspondant aux instructions. Ne retourne pas de texte.",
+          },
+          {
+            role: "user",
+            content: [
+              { type: "text", text: instruction },
+              { type: "image_url", image_url: { url: safeImageDataUrl } },
+            ],
+          },
+        ];
+        const payload = {
+          model: getImageModel(),
+          messages,
+          modalities: ["image"],
+          // Some providers honor this to prefer non-text responses
+          max_output_tokens: 0,
+        };
+        const data = await openrouterFetch<OpenRouterChatCompletionResponse>(
+          payload,
+          { cache: "no-store" }
+        );
+        const urls = extractOpenRouterImageUrls(data);
+        if (urls[0]) imagesOut.push(urls[0]);
+      } else {
+        const parts = [
+          { text: instruction },
+          { inline_data: { mime_type: mimeType, data: base64Data } },
+        ];
+        const payload = { contents: [{ role: "user", parts }] };
+        const data = await googleAiFetch(payload, { cache: "no-store" });
+        const urls = extractGoogleImageUrls(data);
+        if (urls[0]) imagesOut.push(urls[0]);
+      }
     }
 
     if (imagesOut.length === 0) {
@@ -120,7 +169,9 @@ export async function POST(req: NextRequest) {
         { status: 502 }
       );
     }
-    const payload: { images: string[]; instructions?: string[] } = { images: imagesOut };
+    const payload: { images: string[]; instructions?: string[] } = {
+      images: imagesOut,
+    };
     // Help debugging locally by returning the exact instructions
     try {
       if (process.env.NODE_ENV !== "production") {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -111,9 +111,20 @@ export default function Home() {
       // Ne pas scroller tout de suite; on scrollera après avoir des images
     } catch {}
     try {
+      const provider = (() => {
+        try {
+          return localStorage.getItem("imageProvider");
+        } catch {
+          return null;
+        }
+      })();
+      const headers: Record<string, string> = {
+        "Content-Type": "application/json",
+      };
+      if (provider) headers["X-Image-Provider"] = provider;
       const imgRes = await fetch("/api/generate-images", {
         method: "POST",
-        headers: { "Content-Type": "application/json" },
+        headers,
         body: JSON.stringify({ imageDataUrl, options, count: 1 }),
       });
       const imgJson = await imgRes.json();

--- a/src/app/parametres/page.tsx
+++ b/src/app/parametres/page.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from "react";
 import { authClient } from "@/lib/auth-client";
 
 type ThemeMode = "system" | "light" | "dark";
+type ImageProvider = "google" | "openrouter";
 
 function applyTheme(mode: ThemeMode) {
   try {
@@ -30,6 +31,9 @@ export default function SettingsPage() {
   const [mode, setMode] = useState<ThemeMode>("system");
   const [savingTheme, setSavingTheme] = useState(false);
 
+  const [provider, setProvider] = useState<ImageProvider>("google");
+  const [savingProvider, setSavingProvider] = useState(false);
+
   const [name, setName] = useState("");
   const [email, setEmail] = useState("");
   const [profileMsg, setProfileMsg] = useState<string | null>(null);
@@ -53,6 +57,13 @@ export default function SettingsPage() {
   }, []);
 
   useEffect(() => {
+    try {
+      const stored = localStorage.getItem("imageProvider") as ImageProvider | null;
+      if (stored === "google" || stored === "openrouter") setProvider(stored);
+    } catch {}
+  }, []);
+
+  useEffect(() => {
     setName(user?.name || "");
     setEmail(user?.email || "");
   }, [user?.name, user?.email]);
@@ -64,6 +75,18 @@ export default function SettingsPage() {
       applyTheme(next);
     } finally {
       setSavingTheme(false);
+    }
+  }
+
+  async function saveProvider(next: ImageProvider) {
+    setSavingProvider(true);
+    try {
+      setProvider(next);
+      try {
+        localStorage.setItem("imageProvider", next);
+      } catch {}
+    } finally {
+      setSavingProvider(false);
     }
   }
 
@@ -140,6 +163,32 @@ export default function SettingsPage() {
                 disabled={savingTheme}
               />
               {m === "system" ? "Système" : m === "light" ? "Clair" : "Sombre"}
+            </label>
+          ))}
+        </div>
+      </section>
+
+      <section className="mb-6 rounded-2xl border border-gray-200 dark:border-gray-800 bg-white/70 dark:bg-gray-900/70 p-4">
+        <h2 className="text-base font-semibold mb-3 uppercase tracking-wide">Génération d&apos;images</h2>
+        <div className="grid gap-2 sm:grid-cols-2">
+          {(["google", "openrouter"] as ImageProvider[]).map((p) => (
+            <label
+              key={p}
+              className={`flex items-center gap-2 rounded-md border p-2 text-sm cursor-pointer ${
+                provider === p
+                  ? "border-brand-600 bg-brand-50/60 dark:bg-brand-900/10"
+                  : "border-gray-200 dark:border-gray-700"
+              }`}
+            >
+              <input
+                type="radio"
+                name="image-provider"
+                value={p}
+                checked={provider === p}
+                onChange={() => saveProvider(p)}
+                disabled={savingProvider}
+              />
+              {p === "google" ? "Google AI" : "OpenRouter"}
             </label>
           ))}
         </div>

--- a/src/app/resultats/[id]/page.tsx
+++ b/src/app/resultats/[id]/page.tsx
@@ -123,9 +123,20 @@ export default function ResultatsPage() {
       setStep("images");
       setProgress(20);
       context = "Génération des images";
+      const provider = (() => {
+        try {
+          return localStorage.getItem("imageProvider");
+        } catch {
+          return null;
+        }
+      })();
+      const headers: Record<string, string> = {
+        "Content-Type": "application/json",
+      };
+      if (provider) headers["X-Image-Provider"] = provider;
       const imgRes = await fetch("/api/generate-images", {
         method: "POST",
-        headers: { "Content-Type": "application/json" },
+        headers,
         body: JSON.stringify({ imageDataUrl: item.source, options: item.meta?.options, count: 1 }),
       });
       const imgJson = await imgRes.json();

--- a/src/lib/google-ai.ts
+++ b/src/lib/google-ai.ts
@@ -1,0 +1,19 @@
+export const GOOGLE_AI_URL = "https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash-image-preview:generateContent";
+
+export async function googleAiFetch<T = unknown>(payload: Record<string, unknown>, init?: RequestInit): Promise<T> {
+  const apiKey = process.env.GOOGLE_AI_API_KEY;
+  if (!apiKey) {
+    throw new Error("Missing GOOGLE_AI_API_KEY. Add it to .env.local (see .env.example).");
+  }
+  const res = await fetch(`${GOOGLE_AI_URL}?key=${apiKey}`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(payload),
+    ...init,
+  });
+  if (!res.ok) {
+    const text = await res.text().catch(() => "");
+    throw new Error(`Google AI error ${res.status}: ${text}`);
+  }
+  return (await res.json()) as T;
+}

--- a/src/lib/image.ts
+++ b/src/lib/image.ts
@@ -52,7 +52,7 @@ export async function normalizeImageDataUrl(dataUrl: string): Promise<string> {
       .jpeg({ quality: 85 })
       .toBuffer();
     return `data:image/jpeg;base64,${out.toString("base64")}`;
-  } catch (e) {
+  } catch {
     throw new Error("Failed to normalize image");
   }
 }


### PR DESCRIPTION
## Summary
- add Google AI client and switch image generation provider dynamically
- allow selecting image provider in settings and via local storage
- document Google AI setup and environment variables
- tighten Google AI response typing and clean up unused variable

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c06bddd0d48333af60274ee9ab270a